### PR TITLE
Introduce a new config to manage rc type change functionality:

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -308,6 +308,6 @@
 	<setup key="wizardsetup" title="Wizard setup">
 		<item level="0" text="Setup mode" description="Configure which access level to use for the configuration menu. Expert level gives access to all items.">config.usage.setup_level</item>
 		<item level="0" text="Enable HDMI-CEC" description="When enabled, HDMI-CEC is enabled with standard configuration" requires="HasHDMI-CEC">config.hdmicec.enabled</item>
-		<item level="0" text="Multi remote control support" description="Let you change RC type but use it with care." requires="RcTypeChangable">config.usage.multirc</item>
+		<item level="0" text="Multi remote control support" description="Let you change RC type but use it with care." requires="RcTypeChangable">config.plugins.remotecontroltype.multirc</item>
 	</setup>
 </setupxml>

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -223,14 +223,6 @@
 		<item level="2" text="Never decrypt while recording" description="Never decrypt the content while recording. This overrides the individual timer settings globally. If enabled, recordings are stored in crypted presentation and must be decrypted afterwards (sometimes called offline decoding). Default: off.">config.recording.never_decrypt</item>
 		<item level="2" text="Offline decode delay (ms)" requires="HasOfflineDecoding" description="Configure the offline decoding delay in milliseconds. The configured delay is observed at each control word parity change.">config.recording.offline_decode_delay</item>
 	</setup>
-	<setup key="hdmirecord" title="HDMI recording">
-		<item level="0" text="Bitrate" description="The bitrate of the video encoder. Larger value improves quality and increases file size.">config.hdmirecord.bitrate</item>
-		<item level="0" text="Width" description="The width of the picture. The input will be scaled to match this value.">config.hdmirecord.width</item>
-		<item level="0" text="Height" description="The height of the picture. The input will be scaled to match this value.">config.hdmirecord.height</item>
-		<item level="0" text="Frame rate" description="The frame rate of the recording. Ideally, this will match the frame rate of the source or be an integer multiple. If in doubt, set to 60, which should work with most sources.">config.hdmirecord.framerate</item>
-		<item level="2" text="Interlaced" description="In most cases this should be set to No. Only enable if you have a very specific need.">config.hdmirecord.interlaced</item>
-		<item level="1" text="Aspect ratio" description="The aspect ratio of the recording.">config.hdmirecord.aspectratio</item>
-	</setup>
 	<setup key="fanspeed" title="Fan speed control" requires="FanPWM">
 		<item level="0" text="Normal speed" description="The speed of the fan when the %s %s is in normal use.">config.fans[0].pwm</item>
 		<item level="0" text="Standby speed" description="The speed of the fan when the %s %s is in standby mode.">config.fans[0].pwm_standby</item>
@@ -315,8 +307,7 @@
 	</setup>
 	<setup key="wizardsetup" title="Wizard setup">
 		<item level="0" text="Setup mode" description="Configure which access level to use for the configuration menu. Expert level gives access to all items.">config.usage.setup_level</item>
-		<item level="0" text="Alternative numbering mode" description="When enabled, channel numbering will start at '1' for each bouquet.">config.usage.alternative_number_mode</item>
-		<item level="0" text="Show picons in channel selection list" description="Configure if service picons will be shown in the channel selection list.">config.usage.service_icon_enable</item>
 		<item level="0" text="Enable HDMI-CEC" description="When enabled, HDMI-CEC is enabled with standard configuration" requires="HasHDMI-CEC">config.hdmicec.enabled</item>
+		<item level="0" text="Multi remote control support" description="Let you change RC type but use it with care." requires="RcTypeChangable">config.usage.multirc</item>
 	</setup>
 </setupxml>

--- a/lib/python/Components/InputDevice.py
+++ b/lib/python/Components/InputDevice.py
@@ -200,7 +200,7 @@ config.plugins.remotecontroltype.rctype = ConfigInteger(default = int(getRCType(
 
 class RcTypeControl():
 	def __init__(self):
-		if SystemInfo["RcTypeChangable"]:
+		if SystemInfo["RcTypeChangable"] and config.usage.multirc.value is True:
 			self.isSupported = True
 			if config.plugins.remotecontroltype.rctype.value != 0:
 				self.writeRcType(config.plugins.remotecontroltype.rctype.value)

--- a/lib/python/Components/InputDevice.py
+++ b/lib/python/Components/InputDevice.py
@@ -197,10 +197,11 @@ iInputDevices = inputDevices()
 
 config.plugins.remotecontroltype = ConfigSubsection()
 config.plugins.remotecontroltype.rctype = ConfigInteger(default = int(getRCType()))
+config.plugins.remotecontroltype.multirc = ConfigYesNo(default = False)
 
 class RcTypeControl():
 	def __init__(self):
-		if SystemInfo["RcTypeChangable"] and config.usage.multirc.value is True:
+		if SystemInfo["RcTypeChangable"] and config.plugins.remotecontroltype.multirc is True:
 			self.isSupported = True
 			if config.plugins.remotecontroltype.rctype.value != 0:
 				self.writeRcType(config.plugins.remotecontroltype.rctype.value)

--- a/lib/python/Components/Makefile.am
+++ b/lib/python/Components/Makefile.am
@@ -22,7 +22,7 @@ install_PYTHON = \
 	Keyboard.py Sensors.py FanControl.py HdmiCec.py RcModel.py \
 	Netlink.py InputHotplug.py \
 	ImportChannels.py ChannelsImporter.py ClientMode.py \
-	HdmiRecord.py NetworkTime.py StackTrace.py PowerTimerList.py EpgLoadSave.py
+	NetworkTime.py StackTrace.py PowerTimerList.py EpgLoadSave.py
 
 if ENABLE_QBOXHD
 install_PYTHON += SenseWheel.py

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -132,6 +132,8 @@ def InitUsageConfig():
 	config.usage.tuxtxt_TTFHeightFactor16.addNotifier(patchTuxtxtConfFile, initial_call = False, immediate_feedback = False)
 	config.usage.tuxtxt_CleanAlgo.addNotifier(patchTuxtxtConfFile, initial_call = False, immediate_feedback = False)
 
+	config.usage.multirc = ConfigYesNo(default = False)
+
 	config.usage.sort_settings = ConfigYesNo(default=False)
 	choicelist = []
 	for i in (10, 30):

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -132,8 +132,6 @@ def InitUsageConfig():
 	config.usage.tuxtxt_TTFHeightFactor16.addNotifier(patchTuxtxtConfFile, initial_call = False, immediate_feedback = False)
 	config.usage.tuxtxt_CleanAlgo.addNotifier(patchTuxtxtConfFile, initial_call = False, immediate_feedback = False)
 
-	config.usage.multirc = ConfigYesNo(default = False)
-
 	config.usage.sort_settings = ConfigYesNo(default=False)
 	choicelist = []
 	for i in (10, 30):

--- a/mytest.py
+++ b/mytest.py
@@ -633,9 +633,9 @@ Components.AVSwitch.InitAVSwitch()
 profile("FanControl")
 from Components.FanControl import fancontrol
 
-profile("HdmiRecord")
-import Components.HdmiRecord
-Components.HdmiRecord.InitHdmiRecord()
+#profile("HdmiRecord")
+#import Components.HdmiRecord
+#Components.HdmiRecord.InitHdmiRecord()
 
 profile("RecordingConfig")
 import Components.RecordingConfig


### PR DESCRIPTION
Enabling this function leads some STBs to bootloop although they have the /proc/stb/ir/rc/type path so that check isn't enough and also why block this feature on some hardwares when we can disable the function by default and let users manage it.

So now we check the requirement which is /proc/stb/ir/rc/type and let users to enable it if they have the requirement.

Also disable HDMI record for SH4 as there's no HDMI-In